### PR TITLE
show depth of zoomed tree

### DIFF
--- a/src/FlameGraph.elm
+++ b/src/FlameGraph.elm
@@ -25,8 +25,8 @@ type StackFrame
 
 
 type alias Viewer a =
-    (StackFrame -> List StackFrame -> a)
-    -> (StackFrame -> List StackFrame -> a)
+    (StackFrame -> a)
+    -> (StackFrame -> a)
     -> List StackFrame
     -> Html a
 
@@ -63,8 +63,8 @@ viewRow viewChildren barStyles onBarHover onBarClick frames =
                             [ span
                                 [ style barStyles
                                 , title name
-                                , onClick (onBarClick frame frames)
-                                , onMouseEnter (onBarHover frame frames)
+                                , onClick (onBarClick frame)
+                                , onMouseEnter (onBarHover frame)
                                 ]
                                 [ span [ style labelStyles ] [ text name ] ]
                             , viewChildren onBarHover onBarClick children
@@ -106,8 +106,8 @@ labelStyles =
 
 
 viewFromRoot :
-    (StackFrame -> List StackFrame -> a)
-    -> (StackFrame -> List StackFrame -> a)
+    (StackFrame -> a)
+    -> (StackFrame -> a)
     -> StackFrame
     -> List StackFrame
     -> Html a

--- a/src/FlameGraph.elm
+++ b/src/FlameGraph.elm
@@ -24,12 +24,20 @@ type StackFrame
 -- Render
 
 
-view :
+type alias Viewer a =
     (StackFrame -> List StackFrame -> a)
     -> (StackFrame -> List StackFrame -> a)
     -> List StackFrame
     -> Html a
+
+
+view : Viewer a
 view onBarHover onBarClick frames =
+    viewRow view barStyles onBarHover onBarClick frames
+
+
+viewRow : Viewer a -> List ( String, String ) -> Viewer a
+viewRow viewChildren barStyles onBarHover onBarClick frames =
     let
         total : Int
         total =
@@ -59,7 +67,7 @@ view onBarHover onBarClick frames =
                                 , onMouseEnter (onBarHover frame frames)
                                 ]
                                 [ span [ style labelStyles ] [ text name ] ]
-                            , view onBarHover onBarClick children
+                            , viewChildren onBarHover onBarClick children
                             ]
             )
             frames
@@ -109,19 +117,21 @@ viewFromRoot onBarHover onBarClick frame root =
         preBars =
             stack frame root
                 |> List.map
-                    (\(StackFrame { name, count, children }) ->
-                        view onBarHover
+                    (List.singleton
+                        >> viewRow
+                            (\_ _ _ -> noHtml)
+                            (( "opacity", "0.5" ) :: barStyles)
+                            onBarHover
                             onBarClick
-                            [ StackFrame
-                                { name = name
-                                , count = count
-                                , children = []
-                                }
-                            ]
                     )
     in
     div []
         (preBars ++ [ view onBarHover onBarClick [ frame ] ])
+
+
+noHtml : Html a
+noHtml =
+    text ""
 
 
 stack : StackFrame -> List StackFrame -> List StackFrame

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -135,15 +135,15 @@ view model =
         , case ( model.selected, model.frames ) of
             ( Just selected, Just root ) ->
                 FlameGraph.viewFromRoot
-                    (\frame _ -> FrameHover frame)
-                    (\frame _ -> SelectFrame frame)
+                    FrameHover
+                    SelectFrame
                     selected
                     root
 
             ( _, Just root ) ->
                 FlameGraph.view
-                    (\frame _ -> FrameHover frame)
-                    (\frame _ -> SelectFrame frame)
+                    FrameHover
+                    SelectFrame
                     root
 
             _ ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -19,7 +19,7 @@ main =
 
 type alias Model =
     { frames : Maybe (List StackFrame)
-    , selected : Maybe (List StackFrame)
+    , selected : Maybe StackFrame
     , hovered : Maybe StackFrame
     }
 
@@ -33,7 +33,7 @@ initialModel =
 
 
 type Msg
-    = SelectFrames (List StackFrame)
+    = SelectFrame StackFrame
     | ClearSelected
     | FrameHover StackFrame
     | FetchExample (Result Http.Error String)
@@ -42,8 +42,8 @@ type Msg
 update : Msg -> Model -> ( Model, Cmd Msg )
 update action model =
     case action of
-        SelectFrames frames ->
-            ( { model | selected = Just frames }, Cmd.none )
+        SelectFrame frame ->
+            ( { model | selected = Just frame }, Cmd.none )
 
         ClearSelected ->
             ( { model | selected = Nothing }, Cmd.none )
@@ -83,12 +83,6 @@ containerStyles =
 view : Model -> Html Msg
 view model =
     let
-        flames : List StackFrame -> Html Msg
-        flames =
-            FlameGraph.view
-                (\frame _ -> FrameHover frame)
-                (\frame _ -> SelectFrames [ frame ])
-
         sumFrames : List StackFrame -> Int
         sumFrames =
             List.map
@@ -139,11 +133,18 @@ view model =
                     text ""
             ]
         , case ( model.selected, model.frames ) of
-            ( Just selected, _ ) ->
-                flames selected
+            ( Just selected, Just root ) ->
+                FlameGraph.viewFromRoot
+                    (\frame _ -> FrameHover frame)
+                    (\frame _ -> SelectFrame frame)
+                    selected
+                    root
 
             ( _, Just root ) ->
-                flames root
+                FlameGraph.view
+                    (\frame _ -> FrameHover frame)
+                    (\frame _ -> SelectFrame frame)
+                    root
 
             _ ->
                 text "Loading..."


### PR DESCRIPTION
as you zoom, you'll see the full depth of the tree with parent frames shrunk horizontally to the width of the selected frame. you can click up and down the tree to explore.

<img width="839" alt="screen shot 2018-04-09 at 10 49 34 pm" src="https://user-images.githubusercontent.com/820696/38533651-4ef1d328-3c48-11e8-8de3-0b6b3627358f.png">
